### PR TITLE
fix: Update link in footer to point to pub.html

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
         <hr>
         <footer>
-            <p>&copy; Grupo Programadores Brasil  - <a href="{{site.url}}/modelo/pub.md">modelo para publicação</a>.</p>
+            <p>&copy; Grupo Programadores Brasil  - <a href="{{site.url}}/modelo/pub.html">modelo para publicação</a>.</p>
         </footer>
     </div><!--/row-->
 


### PR DESCRIPTION
> # O que este pull request faz?
> * [x] Atualiza o  link no rodapé apontando para a página "_modelo de publicação_" foi atualizado para usar a extensão `.html `em vez de `.md`.

>Com essa alteração, o link funcionará como esperado e irá direcionar o usuário para a página **Modelo para publicação**.
